### PR TITLE
Split Task Graph (round 2)

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -17,92 +17,95 @@ namespace nb = nanobind;
 
 namespace GPUHideSeek {
 
-NB_MODULE(gpu_hideseek, m) {
-    madrona::py::setupMadronaSubmodule(m);
+    NB_MODULE(gpu_hideseek, m) {
+        madrona::py::setupMadronaSubmodule(m);
 
-    nb::enum_<SimFlags>(m, "SimFlags", nb::is_arithmetic())
-        .value("Default", SimFlags::Default)
-        .value("UseFixedWorld", SimFlags::UseFixedWorld)
-        .value("IgnoreEpisodeLength", SimFlags::IgnoreEpisodeLength)
-        .value("RandomFlipTeams", SimFlags::RandomFlipTeams)
-    ;
+        nb::enum_<SimFlags>(m, "SimFlags", nb::is_arithmetic())
+            .value("Default", SimFlags::Default)
+            .value("UseFixedWorld", SimFlags::UseFixedWorld)
+            .value("IgnoreEpisodeLength", SimFlags::IgnoreEpisodeLength)
+            .value("RandomFlipTeams", SimFlags::RandomFlipTeams)
+            ;
 
-    nb::class_<Manager> (m, "HideAndSeekSimulator")
-        .def("__init__", [](Manager *self,
-                            madrona::py::PyExecMode exec_mode,
-                            int64_t gpu_id,
-                            int64_t num_worlds,
-                            int64_t sim_flags,
-                            uint32_t rand_seed,
-                            uint32_t min_hiders,
-                            uint32_t max_hiders,
-                            uint32_t min_seekers,
-                            uint32_t max_seekers,
-                            uint32_t num_pbt_policies,
-                            bool enable_batch_render,
-                            int64_t batch_render_width,
-                            int64_t batch_render_height) {
-            new (self) Manager(Manager::Config {
-                .execMode = exec_mode,
-                .gpuID = (int)gpu_id,
-                .numWorlds = (uint32_t)num_worlds,
-                .simFlags = (SimFlags)sim_flags,
-                .randSeed = rand_seed,
-                .minHiders = min_hiders,
-                .maxHiders = max_hiders,
-                .minSeekers = min_seekers,
-                .maxSeekers = max_seekers,
-                .numPBTPolicies = num_pbt_policies,
-                .enableBatchRenderer = enable_batch_render,
-                .batchRenderViewWidth = (uint32_t)batch_render_width,
-                .batchRenderViewHeight = (uint32_t)batch_render_height,
-            });
-        }, nb::arg("exec_mode"),
-           nb::arg("gpu_id"),
-           nb::arg("num_worlds"),
-           nb::arg("sim_flags"),
-           nb::arg("rand_seed"),
-           nb::arg("min_hiders"),
-           nb::arg("max_hiders"),
-           nb::arg("min_seekers"),
-           nb::arg("max_seekers"),
-           nb::arg("num_pbt_policies"),
-           nb::arg("enable_batch_renderer") = false,
-           nb::arg("batch_render_width") = 64,
-           nb::arg("batch_render_height") = 64)
-        .def("init", &Manager::init)
-        .def("step", &Manager::step)
-        .def("reset_tensor", &Manager::resetTensor)
-        .def("done_tensor", &Manager::doneTensor)
-        .def("prep_counter_tensor", &Manager::prepCounterTensor)
-        .def("action_tensor", &Manager::actionTensor)
-        .def("reward_tensor", &Manager::rewardTensor)
-        .def("self_data_tensor", &Manager::selfDataTensor)
-        .def("self_type_tensor", &Manager::selfTypeTensor)
-        .def("self_mask_tensor", &Manager::selfMaskTensor)
-        .def("agent_data_tensor", &Manager::agentDataTensor)
-        .def("box_data_tensor", &Manager::boxDataTensor)
-        .def("ramp_data_tensor", &Manager::rampDataTensor)
-        .def("visible_agents_mask_tensor", &Manager::visibleAgentsMaskTensor)
-        .def("visible_boxes_mask_tensor", &Manager::visibleBoxesMaskTensor)
-        .def("visible_ramps_mask_tensor", &Manager::visibleRampsMaskTensor)
-        .def("global_positions_tensor", &Manager::globalPositionsTensor)
-        .def("depth_tensor", &Manager::depthTensor)
-        .def("rgb_tensor", &Manager::rgbTensor)
-        .def("lidar_tensor", &Manager::lidarTensor)
-        .def("seed_tensor", &Manager::seedTensor)
-        .def("jax", madrona::py::JAXInterface::buildEntry<
-                &Manager::trainInterface,
-                &Manager::init,
-                &Manager::step
+        nb::class_<Manager>(m, "HideAndSeekSimulator")
+            .def("__init__", [](Manager* self,
+                madrona::py::PyExecMode exec_mode,
+                int64_t gpu_id,
+                int64_t num_worlds,
+                int64_t sim_flags,
+                uint32_t rand_seed,
+                uint32_t min_hiders,
+                uint32_t max_hiders,
+                uint32_t min_seekers,
+                uint32_t max_seekers,
+                uint32_t num_pbt_policies,
+                bool enable_batch_render,
+                int64_t batch_render_width,
+                int64_t batch_render_height) {
+                    new (self) Manager(Manager::Config{
+                        .execMode = exec_mode,
+                        .gpuID = (int)gpu_id,
+                        .numWorlds = (uint32_t)num_worlds,
+                        .simFlags = (SimFlags)sim_flags,
+                        .randSeed = rand_seed,
+                        .minHiders = min_hiders,
+                        .maxHiders = max_hiders,
+                        .minSeekers = min_seekers,
+                        .maxSeekers = max_seekers,
+                        .numPBTPolicies = num_pbt_policies,
+                        .enableBatchRenderer = enable_batch_render,
+                        .batchRenderViewWidth = (uint32_t)batch_render_width,
+                        .batchRenderViewHeight = (uint32_t)batch_render_height,
+                        });
+                }, nb::arg("exec_mode"),
+                    nb::arg("gpu_id"),
+                    nb::arg("num_worlds"),
+                    nb::arg("sim_flags"),
+                    nb::arg("rand_seed"),
+                    nb::arg("min_hiders"),
+                    nb::arg("max_hiders"),
+                    nb::arg("min_seekers"),
+                    nb::arg("max_seekers"),
+                    nb::arg("num_pbt_policies"),
+                    nb::arg("enable_batch_renderer") = false,
+                    nb::arg("batch_render_width") = 64,
+                    nb::arg("batch_render_height") = 64)
+            .def("init", &Manager::init)
+                    .def("step", &Manager::step)
+                    .def("simulate", &Manager::simulate)
+                    .def("reset_and_update", &Manager::resetandupdate)
+                    .def("reset_tensor", &Manager::resetTensor)
+                    .def("done_tensor", &Manager::doneTensor)
+                    .def("prep_counter_tensor", &Manager::prepCounterTensor)
+                    .def("action_tensor", &Manager::actionTensor)
+                    .def("reward_tensor", &Manager::rewardTensor)
+                    .def("self_data_tensor", &Manager::selfDataTensor)
+                    .def("self_type_tensor", &Manager::selfTypeTensor)
+                    .def("self_mask_tensor", &Manager::selfMaskTensor)
+                    .def("agent_data_tensor", &Manager::agentDataTensor)
+                    .def("box_data_tensor", &Manager::boxDataTensor)
+                    .def("ramp_data_tensor", &Manager::rampDataTensor)
+                    .def("visible_agents_mask_tensor", &Manager::visibleAgentsMaskTensor)
+                    .def("visible_boxes_mask_tensor", &Manager::visibleBoxesMaskTensor)
+                    .def("visible_ramps_mask_tensor", &Manager::visibleRampsMaskTensor)
+                    .def("global_positions_tensor", &Manager::globalPositionsTensor)
+                    .def("depth_tensor", &Manager::depthTensor)
+                    .def("rgb_tensor", &Manager::rgbTensor)
+                    .def("lidar_tensor", &Manager::lidarTensor)
+                    .def("seed_tensor", &Manager::seedTensor)
+                    .def("episode_result_tensor", &Manager::episodeResultTensor)
+                    .def("jax", madrona::py::JAXInterface::buildEntry<
+                        &Manager::trainInterface,
+                        &Manager::init,
+                        &Manager::step
 #ifdef MADRONA_MWGPU_SUPPORT
-                ,
-                &Manager::gpuStreamInit,
-                &Manager::gpuStreamStep
+                        ,
+                        &Manager::gpuStreamInit,
+                        &Manager::gpuStreamStep
 #endif
-             >())
+                    >())
 
-    ;
-}
+                    ;
+    }
 
 }

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -25,6 +25,7 @@ namespace GPUHideSeek {
             .value("UseFixedWorld", SimFlags::UseFixedWorld)
             .value("IgnoreEpisodeLength", SimFlags::IgnoreEpisodeLength)
             .value("RandomFlipTeams", SimFlags::RandomFlipTeams)
+            .value("ZeroAgentVelocity", SimFlags::ZeroAgentVelocity)
             ;
 
         nb::class_<Manager>(m, "HideAndSeekSimulator")

--- a/src/mgr.cpp
+++ b/src/mgr.cpp
@@ -27,1002 +27,1178 @@ using namespace madrona::py;
 
 namespace GPUHideSeek {
 
-struct RenderGPUState {
-    render::APILibHandle apiLib;
-    render::APIManager apiMgr;
-    render::GPUHandle gpu;
-};
-
-static inline Optional<RenderGPUState> initRenderGPUState(
-    const Manager::Config &mgr_cfg)
-{
-    if (mgr_cfg.extRenderDev || !mgr_cfg.enableBatchRenderer) {
-        return Optional<RenderGPUState>::none();
-    }
-
-    auto render_api_lib = render::APIManager::loadDefaultLib();
-    render::APIManager render_api_mgr(render_api_lib.lib());
-    render::GPUHandle gpu = render_api_mgr.initGPU(mgr_cfg.gpuID);
-
-    return RenderGPUState {
-        .apiLib = std::move(render_api_lib),
-        .apiMgr = std::move(render_api_mgr),
-        .gpu = std::move(gpu),
-    };
-}
-
-static inline Optional<render::RenderManager> initRenderManager(
-    const Manager::Config &mgr_cfg,
-    const Optional<RenderGPUState> &render_gpu_state)
-{
-    if (!mgr_cfg.extRenderDev && !mgr_cfg.enableBatchRenderer) {
-        return Optional<render::RenderManager>::none();
-    }
-
-    render::APIBackend *render_api;
-    render::GPUDevice *render_dev;
-
-    if (render_gpu_state.has_value()) {
-        render_api = render_gpu_state->apiMgr.backend();
-        render_dev = render_gpu_state->gpu.device();
-    } else {
-        render_api = mgr_cfg.extRenderAPI;
-        render_dev = mgr_cfg.extRenderDev;
-    }
-
-    return render::RenderManager(render_api, render_dev, {
-        .enableBatchRenderer = mgr_cfg.enableBatchRenderer,
-        .agentViewWidth = mgr_cfg.batchRenderViewWidth,
-        .agentViewHeight = mgr_cfg.batchRenderViewHeight,
-        .numWorlds = mgr_cfg.numWorlds,
-        .maxViewsPerWorld = mgr_cfg.maxHiders + mgr_cfg.maxSeekers,
-        .maxInstancesPerWorld = 1000,
-        .execMode = mgr_cfg.execMode,
-        .voxelCfg = {},
-    });
-}
-
-struct Manager::Impl {
-    Config cfg;
-    int32_t maxAgentsPerWorld;
-    PhysicsLoader physicsLoader;
-    Optional<RenderGPUState> renderGPUState;
-    Optional<render::RenderManager> renderMgr;
-    WorldReset *resetsPointer;
-    Action *actionsPointer;
-
-    static inline Impl * make(const Config &cfg);
-
-
-    template <EnumType EnumT>
-    Tensor exportStateTensor(EnumT slot,
-                             TensorElementType type,
-                             Span<const int64_t> dimensions);
-
-};
-
-struct Manager::CPUImpl : Manager::Impl {
-    using TaskGraphT =
-        TaskGraphExecutor<Engine, Sim, GPUHideSeek::Config, WorldInit>;
-
-    TaskGraphT cpuExec;
-
-    inline void init();
-    inline void step();
-
-#ifdef MADRONA_MWGPU_SUPPORT
-    inline void gpuStreamInit(cudaStream_t strm, void **buffers, Manager &mgr);
-    inline void gpuStreamStep(cudaStream_t strm, void **buffers, Manager &mgr);
-#endif
-};
-
-void Manager::CPUImpl::init()
-{
-    cpuExec.runTaskGraph(TaskGraphID::Init);
-}
-
-void Manager::CPUImpl::step()
-{
-    cpuExec.runTaskGraph(TaskGraphID::Step);
-}
-
-#ifdef MADRONA_MWGPU_SUPPORT
-void Manager::CPUImpl::gpuStreamInit(cudaStream_t, void **, Manager &)
-{
-    assert(false);
-}
-
-void Manager::CPUImpl::gpuStreamStep(cudaStream_t, void **, Manager &)
-{
-    assert(false);
-}
-#endif
-
-#ifdef MADRONA_MWGPU_SUPPORT
-
-static inline uint64_t numTensorBytes(const Tensor &t)
-{
-    uint64_t num_items = 1;
-    uint64_t num_dims = t.numDims();
-    for (uint64_t i = 0; i < num_dims; i++) {
-        num_items *= t.dims()[i];
-    }
-
-    return num_items * (uint64_t)t.numBytesPerItem();
-}
-
-struct Manager::CUDAImpl : Manager::Impl {
-    MWCudaExecutor mwGPU;
-    MWCudaLaunchGraph stepGraph;
-
-    inline void init();
-    inline void step();
-
-    inline void copyFromSim(cudaStream_t strm, void *dst, const Tensor &src);
-    inline void copyToSim(cudaStream_t strm, const Tensor &dst, void *src);
-    inline void ** copyOutObservations(
-        cudaStream_t strm, void **buffers, Manager &mgr);
-
-    inline void gpuStreamInit(cudaStream_t strm, void **buffers, Manager &mgr);
-    inline void gpuStreamStep(cudaStream_t strm, void **buffers, Manager &mgr);
-};
-
-void Manager::CUDAImpl::init()
-{
-    MWCudaLaunchGraph init_graph = mwGPU.buildLaunchGraph(TaskGraphID::Init);
-
-    mwGPU.run(init_graph);
-}
-
-void Manager::CUDAImpl::step()
-{
-    mwGPU.run(stepGraph);
-}
-
-void Manager::CUDAImpl::copyFromSim(
-    cudaStream_t strm, void *dst, const Tensor &src)
-{
-    uint64_t num_bytes = numTensorBytes(src);
-
-    REQ_CUDA(cudaMemcpyAsync(dst, src.devicePtr(), num_bytes,
-        cudaMemcpyDeviceToDevice, strm));
-}
-
-void Manager::CUDAImpl::copyToSim(
-    cudaStream_t strm, const Tensor &dst, void *src)
-{
-    uint64_t num_bytes = numTensorBytes(dst);
-
-    REQ_CUDA(cudaMemcpyAsync(dst.devicePtr(), src, num_bytes,
-        cudaMemcpyDeviceToDevice, strm));
-}
-
-void ** Manager::CUDAImpl::copyOutObservations(
-    cudaStream_t strm,
-    void **buffers,
-    Manager &mgr)
-
-{
-    // Observations
-    copyFromSim(strm, *buffers++, mgr.prepCounterTensor());
-    copyFromSim(strm, *buffers++, mgr.selfDataTensor());
-    copyFromSim(strm, *buffers++, mgr.selfTypeTensor());
-    copyFromSim(strm, *buffers++, mgr.selfMaskTensor());
-    copyFromSim(strm, *buffers++, mgr.lidarTensor());
-
-    copyFromSim(strm, *buffers++, mgr.agentDataTensor());
-    copyFromSim(strm, *buffers++, mgr.boxDataTensor());
-    copyFromSim(strm, *buffers++, mgr.rampDataTensor());
-    copyFromSim(strm, *buffers++, mgr.visibleAgentsMaskTensor());
-    copyFromSim(strm, *buffers++, mgr.visibleBoxesMaskTensor());
-    copyFromSim(strm, *buffers++, mgr.visibleRampsMaskTensor());
-
-    return buffers;
-}
-
-void Manager::CUDAImpl::gpuStreamInit(
-    cudaStream_t strm, void **buffers, Manager &mgr)
-{
-    MWCudaLaunchGraph init_graph = mwGPU.buildLaunchGraph(TaskGraphID::Init);
-
-    mwGPU.runAsync(init_graph, strm);
-    copyOutObservations(strm, buffers, mgr);
-
-    REQ_CUDA(cudaStreamSynchronize(strm));
-}
-
-void Manager::CUDAImpl::gpuStreamStep(
-    cudaStream_t strm, void **buffers, Manager &mgr)
-{
-    copyToSim(strm, mgr.actionTensor(), *buffers++);
-    copyToSim(strm, mgr.resetTensor(), *buffers++);
-
-    if (cfg.numPBTPolicies > 0) {
-        copyToSim(strm, mgr.policyAssignmentsTensor(), *buffers++);
-        //copyToSim(strm, mgr.rewardHyperParamsTensor(), *buffers++);
-    }
-
-    mwGPU.runAsync(stepGraph, strm);
-
-    buffers = copyOutObservations(strm, buffers, mgr);
-
-    copyFromSim(strm, *buffers++, mgr.rewardTensor());
-    copyFromSim(strm, *buffers++, mgr.doneTensor());
-
-    if (cfg.numPBTPolicies > 0) {
-        copyFromSim(strm, *buffers++, mgr.episodeResultTensor());
-    }
-}
-#endif
-
-static void loadPhysicsObjects(PhysicsLoader &loader)
-{
-    SourceCollisionPrimitive sphere_prim {
-        .type = CollisionPrimitive::Type::Sphere,
-        .sphere = CollisionPrimitive::Sphere {
-            .radius = 1.f,
-        },
+    struct RenderGPUState {
+        render::APILibHandle apiLib;
+        render::APIManager apiMgr;
+        render::GPUHandle gpu;
     };
 
-    SourceCollisionPrimitive plane_prim {
-        .type = CollisionPrimitive::Type::Plane,
-        .plane = {},
-    };
-
-    char import_err_buffer[4096];
-    auto imported_hulls = imp::ImportedAssets::importFromDisk({
-        (std::filesystem::path(DATA_DIR) / "cube_collision.obj").string().c_str(),
-        (std::filesystem::path(DATA_DIR) / "wall_collision.obj").string().c_str(),
-        (std::filesystem::path(DATA_DIR) / "agent_collision.obj").string().c_str(),
-        (std::filesystem::path(DATA_DIR) / "ramp_collision.obj").string().c_str(),
-        (std::filesystem::path(DATA_DIR) / "elongated_collision.obj").string().c_str(),
-    }, import_err_buffer, true);
-
-    if (!imported_hulls.has_value()) {
-        FATAL("%s", import_err_buffer);
-    }
-
-    DynArray<imp::SourceMesh> src_convex_hulls(
-        imported_hulls->objects.size());
-
-    DynArray<DynArray<SourceCollisionPrimitive>> prim_arrays(0);
-    HeapArray<SourceCollisionObject> src_objs((uint32_t)SimObject::NumObjects);
-
-    // Sphere (0)
-    src_objs[(uint32_t)SimObject::Sphere] = {
-        .prims = Span<const SourceCollisionPrimitive>(&sphere_prim, 1),
-        .invMass = 1.f,
-        .friction = {
-            .muS = 0.5f,
-            .muD = 0.5f,
-        },
-    };
-
-    // Plane (1)
-    src_objs[(uint32_t)SimObject::Plane] = {
-        .prims = Span<const SourceCollisionPrimitive>(&plane_prim, 1),
-        .invMass = 0.f,
-        .friction = {
-            .muS = 2.f,
-            .muD = 2.f,
-        },
-    };
-
-    auto setupHull = [&](CountT obj_idx, float inv_mass,
-                         RigidBodyFrictionData friction) {
-        auto meshes = imported_hulls->objects[obj_idx].meshes;
-        DynArray<SourceCollisionPrimitive> prims(meshes.size());
-
-        for (const imp::SourceMesh &mesh : meshes) {
-            src_convex_hulls.push_back(mesh);
-            prims.push_back({
-                .type = CollisionPrimitive::Type::Hull,
-                .hullInput = {
-                    .hullIDX = uint32_t(src_convex_hulls.size() - 1),
-                },
-            });
+    static inline Optional<RenderGPUState> initRenderGPUState(
+        const Manager::Config& mgr_cfg)
+    {
+        if (mgr_cfg.extRenderDev || !mgr_cfg.enableBatchRenderer) {
+            return Optional<RenderGPUState>::none();
         }
 
-        prim_arrays.emplace_back(std::move(prims));
+        auto render_api_lib = render::APIManager::loadDefaultLib();
+        render::APIManager render_api_mgr(render_api_lib.lib());
+        render::GPUHandle gpu = render_api_mgr.initGPU(mgr_cfg.gpuID);
 
-        return SourceCollisionObject {
-            .prims = Span<const SourceCollisionPrimitive>(prim_arrays.back()),
-            .invMass = inv_mass,
-            .friction = friction,
+        return RenderGPUState{
+            .apiLib = std::move(render_api_lib),
+            .apiMgr = std::move(render_api_mgr),
+            .gpu = std::move(gpu),
         };
+    }
+
+    static inline Optional<render::RenderManager> initRenderManager(
+        const Manager::Config& mgr_cfg,
+        const Optional<RenderGPUState>& render_gpu_state)
+    {
+        if (!mgr_cfg.extRenderDev && !mgr_cfg.enableBatchRenderer) {
+            return Optional<render::RenderManager>::none();
+        }
+
+        render::APIBackend* render_api;
+        render::GPUDevice* render_dev;
+
+        if (render_gpu_state.has_value()) {
+            render_api = render_gpu_state->apiMgr.backend();
+            render_dev = render_gpu_state->gpu.device();
+        }
+        else {
+            render_api = mgr_cfg.extRenderAPI;
+            render_dev = mgr_cfg.extRenderDev;
+        }
+
+        return render::RenderManager(render_api, render_dev, {
+            .enableBatchRenderer = mgr_cfg.enableBatchRenderer,
+            .agentViewWidth = mgr_cfg.batchRenderViewWidth,
+            .agentViewHeight = mgr_cfg.batchRenderViewHeight,
+            .numWorlds = mgr_cfg.numWorlds,
+            .maxViewsPerWorld = mgr_cfg.maxHiders + mgr_cfg.maxSeekers,
+            .maxInstancesPerWorld = 1000,
+            .execMode = mgr_cfg.execMode,
+            .voxelCfg = {},
+            });
+    }
+
+    struct Manager::Impl {
+        Config cfg;
+        int32_t maxAgentsPerWorld;
+        PhysicsLoader physicsLoader;
+        Optional<RenderGPUState> renderGPUState;
+        Optional<render::RenderManager> renderMgr;
+        WorldReset* resetsPointer;
+        Action* actionsPointer;
+
+        static inline Impl* make(const Config& cfg);
+
+
+        template <EnumType EnumT>
+        Tensor exportStateTensor(EnumT slot,
+            TensorElementType type,
+            Span<const int64_t> dimensions);
+
     };
 
-    { // Cube
-        src_objs[(uint32_t)SimObject::Cube] = setupHull(0, 0.5f, {
-            .muS = 0.5f,
-            .muD = 2.f,
-        });
-    }
+    struct Manager::CPUImpl : Manager::Impl {
+        using TaskGraphT =
+            TaskGraphExecutor<Engine, Sim, GPUHideSeek::Config, WorldInit>;
 
-    { // Wall
-        src_objs[(uint32_t)SimObject::Wall] = setupHull(1, 0.f, {
-            .muS = 0.5f,
-            .muD = 2.f,
-        });
-    }
+        TaskGraphT cpuExec;
 
-    { // Cylinder
-        src_objs[(uint32_t)SimObject::Hider] = setupHull(2, 1.f, {
-            .muS = 0.5f,
-            .muD = 16.f,
-        });
-    }
+        inline void init();
+        inline void step();
+        inline void simulate();
+        inline void resetandupdate();
 
-    { // Cylinder
-        src_objs[(uint32_t)SimObject::Seeker] = setupHull(2, 1.f, {
-            .muS = 0.5f,
-            .muD = 16.f,
-        });
-    }
-
-    { // Ramp
-        src_objs[(uint32_t)SimObject::Ramp] = setupHull(3, 0.5f, {
-            .muS = 0.5f,
-            .muD = 1.f,
-        });
-    }
-
-    { // Elongated Box
-        src_objs[(uint32_t)SimObject::Box] = setupHull(4, 0.5f, {
-            .muS = 0.5f,
-            .muD = 4.f,
-        });
-    }
-
-    StackAlloc tmp_alloc;
-    RigidBodyAssets rigid_body_assets;
-    CountT num_rigid_body_data_bytes;
-    void *rigid_body_data = RigidBodyAssets::processRigidBodyAssets(
-        src_convex_hulls,
-        src_objs,
-        false,
-        tmp_alloc,
-        &rigid_body_assets,
-        &num_rigid_body_data_bytes);
-
-    if (rigid_body_data == nullptr) {
-        FATAL("Invalid collision hull input");
-    }
-
-    // HACK:
-    rigid_body_assets.metadatas[
-        (uint32_t)SimObject::Hider].mass.invInertiaTensor.x = 0.f;
-    rigid_body_assets.metadatas[
-        (uint32_t)SimObject::Hider].mass.invInertiaTensor.y = 0.f;
-    rigid_body_assets.metadatas[
-        (uint32_t)SimObject::Seeker].mass.invInertiaTensor.x = 0.f;
-    rigid_body_assets.metadatas[
-        (uint32_t)SimObject::Seeker].mass.invInertiaTensor.y = 0.f;
-
-    loader.loadRigidBodies(rigid_body_assets);
-    free(rigid_body_data);
-}
-
-static void loadRenderObjects(render::RenderManager &render_mgr)
-{
-    std::array<std::string, (size_t)SimObject::NumObjects> render_asset_paths;
-    render_asset_paths[(size_t)SimObject::Sphere] =
-        (std::filesystem::path(DATA_DIR) / "sphere.obj").string();
-    render_asset_paths[(size_t)SimObject::Plane] =
-        (std::filesystem::path(DATA_DIR) / "plane.obj").string();
-    render_asset_paths[(size_t)SimObject::Cube] =
-        (std::filesystem::path(DATA_DIR) / "cube_render.obj").string();
-    render_asset_paths[(size_t)SimObject::Wall] =
-        (std::filesystem::path(DATA_DIR) / "wall_render.obj").string();
-    render_asset_paths[(size_t)SimObject::Hider] =
-        (std::filesystem::path(DATA_DIR) / "agent_render.obj").string();
-    render_asset_paths[(size_t)SimObject::Seeker] =
-        (std::filesystem::path(DATA_DIR) / "agent_render.obj").string();
-    render_asset_paths[(size_t)SimObject::Ramp] =
-        (std::filesystem::path(DATA_DIR) / "ramp_render.obj").string();
-    render_asset_paths[(size_t)SimObject::Box] =
-        (std::filesystem::path(DATA_DIR) / "elongated_render.obj").string();
-
-    std::array<const char *, (size_t)SimObject::NumObjects> render_asset_cstrs;
-    for (size_t i = 0; i < render_asset_paths.size(); i++) {
-        render_asset_cstrs[i] = render_asset_paths[i].c_str();
-    }
-
-    std::array<char, 1024> import_err;
-    auto render_assets = imp::ImportedAssets::importFromDisk(
-        render_asset_cstrs, Span<char>(import_err.data(), import_err.size()));
-
-    if (!render_assets.has_value()) {
-        FATAL("Failed to load render assets: %s", import_err);
-    }
-
-    auto materials = std::to_array<imp::SourceMaterial>({
-        { math::Vector4{0.4f, 0.4f, 0.4f, 0.0f}, -1, 0.8f, 0.2f,},
-        { math::Vector4{1.0f, 0.1f, 0.1f, 0.0f}, -1, 0.8f, 0.2f,},
-        { math::Vector4{1.0f, 1.0f, 1.0f, 0.0f}, 1, 0.8f, 1.0f,},
-        { math::Vector4{0.5f, 0.3f, 0.3f, 0.0f},  0, 0.8f, 0.2f,},
-        { render::rgb8ToFloat(191, 108, 10), -1, 0.8f, 0.2f },
-        { render::rgb8ToFloat(12, 144, 150), -1, 0.8f, 0.2f },
-        { render::rgb8ToFloat(230, 230, 230),   -1, 0.8f, 1.0f },
-        { math::Vector4{1.0f, 1.0f, 1.0f, 0.0f}, 2, 0.8f, 1.0f,},
-    });
-
-    // Override materials
-    render_assets->objects[(uint32_t)SimObject::Sphere].meshes[0].materialIDX = 0;
-    render_assets->objects[(uint32_t)SimObject::Plane].meshes[0].materialIDX = 3;
-    render_assets->objects[(uint32_t)SimObject::Cube].meshes[0].materialIDX = 1;
-    render_assets->objects[(uint32_t)SimObject::Wall].meshes[0].materialIDX = 0;
-    render_assets->objects[(uint32_t)SimObject::Hider].meshes[0].materialIDX = 2;
-    render_assets->objects[(uint32_t)SimObject::Hider].meshes[1].materialIDX = 6;
-    render_assets->objects[(uint32_t)SimObject::Hider].meshes[2].materialIDX = 6;
-    render_assets->objects[(uint32_t)SimObject::Seeker].meshes[0].materialIDX = 7;
-    render_assets->objects[(uint32_t)SimObject::Seeker].meshes[1].materialIDX = 6;
-    render_assets->objects[(uint32_t)SimObject::Seeker].meshes[2].materialIDX = 6;
-    render_assets->objects[(uint32_t)SimObject::Ramp].meshes[0].materialIDX = 4;
-    render_assets->objects[(uint32_t)SimObject::Box].meshes[0].materialIDX = 5;
-
-    render_mgr.loadObjects(render_assets->objects, materials, {
-        { (std::filesystem::path(DATA_DIR) /
-           "green_grid.png").string().c_str() },
-        { (std::filesystem::path(DATA_DIR) /
-           "smile.png").string().c_str() },
-        { (std::filesystem::path(DATA_DIR) /
-           "red_smile.png").string().c_str() },
-    });
-
-    render_mgr.configureLighting({
-        { true, math::Vector3{1.0f, 1.0f, -2.0f}, math::Vector3{1.0f, 1.0f, 1.0f} }
-    });
-}
-
-Manager::Impl * Manager::Impl::make(const Config &cfg)
-{
-    GPUHideSeek::Config app_cfg;
-    app_cfg.simFlags = cfg.simFlags;
-    app_cfg.initRandKey = rand::initKey(cfg.randSeed);
-    app_cfg.minHiders = cfg.minHiders;
-    app_cfg.maxHiders = cfg.maxHiders;
-    app_cfg.minSeekers = cfg.minSeekers;
-    app_cfg.maxSeekers = cfg.maxSeekers;
-
-    int32_t max_agents_per_world = cfg.maxHiders + cfg.maxSeekers;
-
-    switch (cfg.execMode) {
-    case ExecMode::CUDA: {
 #ifdef MADRONA_MWGPU_SUPPORT
-        CUcontext cu_ctx = MWCudaExecutor::initCUDA(cfg.gpuID);
-
-        PhysicsLoader phys_loader(cfg.execMode, 10);
-        loadPhysicsObjects(phys_loader);
-
-        ObjectManager *phys_obj_mgr = &phys_loader.getObjectManager();
-        app_cfg.rigidBodyObjMgr = phys_obj_mgr;
-
-        Optional<RenderGPUState> render_gpu_state =
-            initRenderGPUState(cfg);
-
-        Optional<render::RenderManager> render_mgr =
-            initRenderManager(cfg, render_gpu_state);
-
-        if (render_mgr.has_value()) {
-            loadRenderObjects(*render_mgr);
-            app_cfg.renderBridge = render_mgr->bridge();
-         } else {
-            app_cfg.renderBridge = nullptr;
-         }
-
-        HeapArray<WorldInit> world_inits(cfg.numWorlds);
-
-        MWCudaExecutor mwgpu_exec({
-            .worldInitPtr = world_inits.data(),
-            .numWorldInitBytes = sizeof(WorldInit),
-            .userConfigPtr = &app_cfg,
-            .numUserConfigBytes = sizeof(GPUHideSeek::Config),
-            .numWorldDataBytes = sizeof(Sim),
-            .worldDataAlignment = alignof(Sim),
-            .numWorlds = cfg.numWorlds,
-            .numTaskGraphs = (uint32_t)TaskGraphID::NumTaskGraphs,
-            .numExportedBuffers = (uint32_t)ExportID::NumExports,
-        }, {
-            { GPU_HIDESEEK_SRC_LIST },
-            { GPU_HIDESEEK_COMPILE_FLAGS },
-            CompileConfig::OptMode::LTO,
-        }, cu_ctx);
-
-        MWCudaLaunchGraph step_graph = mwgpu_exec.buildLaunchGraph(
-            TaskGraphID::Step);
-
-        WorldReset *world_reset_buffer = 
-            (WorldReset *)mwgpu_exec.getExported((uint32_t)ExportID::Reset);
-
-        Action *agent_actions_buffer = 
-            (Action *)mwgpu_exec.getExported((uint32_t)ExportID::Action);
-
-        HostEventLogging(HostEvent::initEnd);
-        return new CUDAImpl {
-            { 
-                cfg,
-                max_agents_per_world,
-                std::move(phys_loader),
-                std::move(render_gpu_state),
-                std::move(render_mgr),
-                world_reset_buffer,
-                agent_actions_buffer,
-            },
-            std::move(mwgpu_exec),
-            std::move(step_graph),
-        };
-#else
-        FATAL("Madrona was not compiled with CUDA support");
+        inline void gpuStreamInit(cudaStream_t strm, void** buffers, Manager& mgr);
+        inline void gpuStreamStep(cudaStream_t strm, void** buffers, Manager& mgr);
+        inline void gpuStreamSimulate(cudaStream_t strm, void** buffers, Manager& mgr);
+        inline void gpuStreamResetAndUpdate(cudaStream_t strm, void** buffers, Manager& mgr);
 #endif
-    } break;
-    case ExecMode::CPU: {
-        PhysicsLoader phys_loader(cfg.execMode, 10);
-        loadPhysicsObjects(phys_loader);
+    };
 
-        ObjectManager *phys_obj_mgr = &phys_loader.getObjectManager();
-        app_cfg.rigidBodyObjMgr = phys_obj_mgr;
+    void Manager::CPUImpl::init()
+    {
+        cpuExec.runTaskGraph(TaskGraphID::Init);
+    }
 
-        Optional<RenderGPUState> render_gpu_state =
-            initRenderGPUState(cfg);
+    void Manager::CPUImpl::step()
+    {
+        //cpuExec.runTaskGraph(TaskGraphID::Step);
+        cpuExec.runTaskGraph(TaskGraphID::Simulate);
+        cpuExec.runTaskGraph(TaskGraphID::ResetAndUpdate);
+    }
 
-        Optional<render::RenderManager> render_mgr =
-            initRenderManager(cfg, render_gpu_state);
+    void Manager::CPUImpl::simulate()
+    {
+        cpuExec.runTaskGraph(TaskGraphID::Simulate);
+    }
 
-        if (render_mgr.has_value()) {
-            loadRenderObjects(*render_mgr);
-            app_cfg.renderBridge = render_mgr->bridge();
-         } else {
-            app_cfg.renderBridge = nullptr;
-         }
+    void Manager::CPUImpl::resetandupdate()
+    {
+        cpuExec.runTaskGraph(TaskGraphID::ResetAndUpdate);
+    }
 
-        HeapArray<WorldInit> world_inits(cfg.numWorlds);
+#ifdef MADRONA_MWGPU_SUPPORT
+    void Manager::CPUImpl::gpuStreamInit(cudaStream_t, void**, Manager&)
+    {
+        assert(false);
+    }
 
-        CPUImpl::TaskGraphT cpu_exec {
-            ThreadPoolExecutor::Config {
+    void Manager::CPUImpl::gpuStreamStep(cudaStream_t, void**, Manager&)
+    {
+        assert(false);
+    }
+    void Manager::CPUImpl::gpuStreamSimulate(cudaStream_t, void**, Manager&)
+    {
+        assert(false);
+    }
+    void Manager::CPUImpl::gpuStreamResetAndUpdate(cudaStream_t, void**, Manager&)
+    {
+        assert(false);
+    }
+#endif
+
+#ifdef MADRONA_MWGPU_SUPPORT
+
+    static inline uint64_t numTensorBytes(const Tensor& t)
+    {
+        uint64_t num_items = 1;
+        uint64_t num_dims = t.numDims();
+        for (uint64_t i = 0; i < num_dims; i++) {
+            num_items *= t.dims()[i];
+        }
+
+        return num_items * (uint64_t)t.numBytesPerItem();
+    }
+
+    struct Manager::CUDAImpl : Manager::Impl {
+        MWCudaExecutor mwGPU;
+        // MWCudaLaunchGraph stepGraph;
+        MWCudaLaunchGraph simulationGraph;
+        MWCudaLaunchGraph resetandupdateGraph;
+
+        inline void init();
+        inline void step();
+        inline void simulate();
+        inline void resetandupdate();
+
+        inline void copyFromSim(cudaStream_t strm, void* dst, const Tensor& src);
+        inline void copyToSim(cudaStream_t strm, const Tensor& dst, void* src);
+        inline void** copyOutObservations(
+            cudaStream_t strm, void** buffers, Manager& mgr);
+
+        inline void gpuStreamInit(cudaStream_t strm, void** buffers, Manager& mgr);
+        inline void gpuStreamStep(cudaStream_t strm, void** buffers, Manager& mgr);
+        inline void gpuStreamSimulate(cudaStream_t strm, void** buffers, Manager& mgr);
+        inline void gpuStreamResetAndUpdate(cudaStream_t strm, void** buffers, Manager& mrg);
+    };
+
+    void Manager::CUDAImpl::init()
+    {
+        MWCudaLaunchGraph init_graph = mwGPU.buildLaunchGraph(TaskGraphID::Init);
+
+        mwGPU.run(init_graph);
+    }
+
+    void Manager::CUDAImpl::step()
+    {
+        // mwGPU.run(stepGraph);
+        mwGPU.run(simulationGraph);
+        mwGPU.run(resetandupdateGraph);
+    }
+
+    void Manager::CUDAImpl::resetandupdate()
+    {
+        mwGPU.run(resetandupdateGraph);
+    }
+
+
+    void Manager::CUDAImpl::simulate()
+    {
+        mwGPU.run(simulationGraph);
+    }
+
+    void Manager::CUDAImpl::copyFromSim(
+        cudaStream_t strm, void* dst, const Tensor& src)
+    {
+        uint64_t num_bytes = numTensorBytes(src);
+
+        REQ_CUDA(cudaMemcpyAsync(dst, src.devicePtr(), num_bytes,
+            cudaMemcpyDeviceToDevice, strm));
+    }
+
+    void Manager::CUDAImpl::copyToSim(
+        cudaStream_t strm, const Tensor& dst, void* src)
+    {
+        uint64_t num_bytes = numTensorBytes(dst);
+
+        REQ_CUDA(cudaMemcpyAsync(dst.devicePtr(), src, num_bytes,
+            cudaMemcpyDeviceToDevice, strm));
+    }
+
+    void** Manager::CUDAImpl::copyOutObservations(
+        cudaStream_t strm,
+        void** buffers,
+        Manager& mgr)
+
+    {
+        // Observations
+        copyFromSim(strm, *buffers++, mgr.prepCounterTensor());
+        copyFromSim(strm, *buffers++, mgr.selfDataTensor());
+        copyFromSim(strm, *buffers++, mgr.selfTypeTensor());
+        copyFromSim(strm, *buffers++, mgr.selfMaskTensor());
+        copyFromSim(strm, *buffers++, mgr.lidarTensor());
+
+        copyFromSim(strm, *buffers++, mgr.agentDataTensor());
+        copyFromSim(strm, *buffers++, mgr.boxDataTensor());
+        copyFromSim(strm, *buffers++, mgr.rampDataTensor());
+        copyFromSim(strm, *buffers++, mgr.visibleAgentsMaskTensor());
+        copyFromSim(strm, *buffers++, mgr.visibleBoxesMaskTensor());
+        copyFromSim(strm, *buffers++, mgr.visibleRampsMaskTensor());
+
+        return buffers;
+    }
+
+    void Manager::CUDAImpl::gpuStreamInit(
+        cudaStream_t strm, void** buffers, Manager& mgr)
+    {
+        MWCudaLaunchGraph init_graph = mwGPU.buildLaunchGraph(TaskGraphID::Init);
+
+        mwGPU.runAsync(init_graph, strm);
+        copyOutObservations(strm, buffers, mgr);
+
+        REQ_CUDA(cudaStreamSynchronize(strm));
+    }
+
+    void Manager::CUDAImpl::gpuStreamStep(
+        cudaStream_t strm, void** buffers, Manager& mgr)
+    {
+        copyToSim(strm, mgr.actionTensor(), *buffers++);
+        copyToSim(strm, mgr.resetTensor(), *buffers++);
+
+        if (cfg.numPBTPolicies > 0) {
+            copyToSim(strm, mgr.policyAssignmentsTensor(), *buffers++);
+            //copyToSim(strm, mgr.rewardHyperParamsTensor(), *buffers++);
+        }
+
+        // mwGPU.runAsync(stepGraph, strm);
+        mwGPU.runAsync(simulationGraph, strm);
+        mwGPU.runAsync(resetandupdateGraph, strm);
+
+        buffers = copyOutObservations(strm, buffers, mgr);
+
+        copyFromSim(strm, *buffers++, mgr.rewardTensor());
+        copyFromSim(strm, *buffers++, mgr.doneTensor());
+        copyFromSim(strm, *buffers++, mgr.episodeResultTensor());
+    }
+
+    void Manager::CUDAImpl::gpuStreamSimulate(
+        cudaStream_t strm, void** buffers, Manager& mgr)
+    {
+        copyToSim(strm, mgr.actionTensor(), *buffers++);
+        copyToSim(strm, mgr.resetTensor(), *buffers++);
+
+        if (cfg.numPBTPolicies > 0) {
+            copyToSim(strm, mgr.policyAssignmentsTensor(), *buffers++);
+            //copyToSim(strm, mgr.rewardHyperParamsTensor(), *buffers++);
+        }
+
+        mwGPU.runAsync(simulationGraph, strm);
+
+        buffers = copyOutObservations(strm, buffers, mgr);
+
+        copyFromSim(strm, *buffers++, mgr.rewardTensor());
+        copyFromSim(strm, *buffers++, mgr.doneTensor());
+        // copyFromSim(strm, *buffers++, mgr.episodeResultTensor());
+    }
+
+    void Manager::CUDAImpl::gpuStreamResetAndUpdate(
+        cudaStream_t strm, void** buffers, Manager& mgr)
+    {
+        // copyToSim(strm, mgr.actionTensor(), *buffers++);
+        // copyToSim(strm, mgr.resetTensor(), *buffers++);
+
+        if (cfg.numPBTPolicies > 0) {
+            copyToSim(strm, mgr.policyAssignmentsTensor(), *buffers++);
+            //copyToSim(strm, mgr.rewardHyperParamsTensor(), *buffers++);
+        }
+
+        mwGPU.runAsync(resetandupdateGraph, strm);
+
+        buffers = copyOutObservations(strm, buffers, mgr);
+
+        copyFromSim(strm, *buffers++, mgr.rewardTensor());
+        copyFromSim(strm, *buffers++, mgr.doneTensor());
+        copyFromSim(strm, *buffers++, mgr.episodeResultTensor());
+    }
+#endif
+
+    static void loadPhysicsObjects(PhysicsLoader& loader)
+    {
+        SourceCollisionPrimitive sphere_prim{
+            .type = CollisionPrimitive::Type::Sphere,
+            .sphere = CollisionPrimitive::Sphere {
+                .radius = 1.f,
+            },
+        };
+
+        SourceCollisionPrimitive plane_prim{
+            .type = CollisionPrimitive::Type::Plane,
+            .plane = {},
+        };
+
+        char import_err_buffer[4096];
+        auto imported_hulls = imp::ImportedAssets::importFromDisk({
+            (std::filesystem::path(DATA_DIR) / "cube_collision.obj").string().c_str(),
+            (std::filesystem::path(DATA_DIR) / "wall_collision.obj").string().c_str(),
+            (std::filesystem::path(DATA_DIR) / "agent_collision.obj").string().c_str(),
+            (std::filesystem::path(DATA_DIR) / "ramp_collision.obj").string().c_str(),
+            (std::filesystem::path(DATA_DIR) / "elongated_collision.obj").string().c_str(),
+            }, import_err_buffer, true);
+
+        if (!imported_hulls.has_value()) {
+            FATAL("%s", import_err_buffer);
+        }
+
+        DynArray<imp::SourceMesh> src_convex_hulls(
+            imported_hulls->objects.size());
+
+        DynArray<DynArray<SourceCollisionPrimitive>> prim_arrays(0);
+        HeapArray<SourceCollisionObject> src_objs((uint32_t)SimObject::NumObjects);
+
+        // Sphere (0)
+        src_objs[(uint32_t)SimObject::Sphere] = {
+            .prims = Span<const SourceCollisionPrimitive>(&sphere_prim, 1),
+            .invMass = 1.f,
+            .friction = {
+                .muS = 0.5f,
+                .muD = 0.5f,
+            },
+        };
+
+        // Plane (1)
+        src_objs[(uint32_t)SimObject::Plane] = {
+            .prims = Span<const SourceCollisionPrimitive>(&plane_prim, 1),
+            .invMass = 0.f,
+            .friction = {
+                .muS = 2.f,
+                .muD = 2.f,
+            },
+        };
+
+        auto setupHull = [&](CountT obj_idx, float inv_mass,
+            RigidBodyFrictionData friction) {
+                auto meshes = imported_hulls->objects[obj_idx].meshes;
+                DynArray<SourceCollisionPrimitive> prims(meshes.size());
+
+                for (const imp::SourceMesh& mesh : meshes) {
+                    src_convex_hulls.push_back(mesh);
+                    prims.push_back({
+                        .type = CollisionPrimitive::Type::Hull,
+                        .hullInput = {
+                            .hullIDX = uint32_t(src_convex_hulls.size() - 1),
+                        },
+                        });
+                }
+
+                prim_arrays.emplace_back(std::move(prims));
+
+                return SourceCollisionObject{
+                    .prims = Span<const SourceCollisionPrimitive>(prim_arrays.back()),
+                    .invMass = inv_mass,
+                    .friction = friction,
+                };
+            };
+
+        { // Cube
+            src_objs[(uint32_t)SimObject::Cube] = setupHull(0, 0.5f, {
+                .muS = 0.5f,
+                .muD = 2.f,
+                });
+        }
+
+        { // Wall
+            src_objs[(uint32_t)SimObject::Wall] = setupHull(1, 0.f, {
+                .muS = 0.5f,
+                .muD = 2.f,
+                });
+        }
+
+        { // Cylinder
+            src_objs[(uint32_t)SimObject::Hider] = setupHull(2, 1.f, {
+                .muS = 0.5f,
+                .muD = 16.f,
+                });
+        }
+
+        { // Cylinder
+            src_objs[(uint32_t)SimObject::Seeker] = setupHull(2, 1.f, {
+                .muS = 0.5f,
+                .muD = 16.f,
+                });
+        }
+
+        { // Ramp
+            src_objs[(uint32_t)SimObject::Ramp] = setupHull(3, 0.5f, {
+                .muS = 0.5f,
+                .muD = 1.f,
+                });
+        }
+
+        { // Elongated Box
+            src_objs[(uint32_t)SimObject::Box] = setupHull(4, 0.5f, {
+                .muS = 0.5f,
+                .muD = 4.f,
+                });
+        }
+
+        StackAlloc tmp_alloc;
+        RigidBodyAssets rigid_body_assets;
+        CountT num_rigid_body_data_bytes;
+        void* rigid_body_data = RigidBodyAssets::processRigidBodyAssets(
+            src_convex_hulls,
+            src_objs,
+            false,
+            tmp_alloc,
+            &rigid_body_assets,
+            &num_rigid_body_data_bytes);
+
+        if (rigid_body_data == nullptr) {
+            FATAL("Invalid collision hull input");
+        }
+
+        // HACK:
+        rigid_body_assets.metadatas[
+            (uint32_t)SimObject::Hider].mass.invInertiaTensor.x = 0.f;
+        rigid_body_assets.metadatas[
+            (uint32_t)SimObject::Hider].mass.invInertiaTensor.y = 0.f;
+        rigid_body_assets.metadatas[
+            (uint32_t)SimObject::Seeker].mass.invInertiaTensor.x = 0.f;
+        rigid_body_assets.metadatas[
+            (uint32_t)SimObject::Seeker].mass.invInertiaTensor.y = 0.f;
+
+        loader.loadRigidBodies(rigid_body_assets);
+        free(rigid_body_data);
+    }
+
+    static void loadRenderObjects(render::RenderManager& render_mgr)
+    {
+        std::array<std::string, (size_t)SimObject::NumObjects> render_asset_paths;
+        render_asset_paths[(size_t)SimObject::Sphere] =
+            (std::filesystem::path(DATA_DIR) / "sphere.obj").string();
+        render_asset_paths[(size_t)SimObject::Plane] =
+            (std::filesystem::path(DATA_DIR) / "plane.obj").string();
+        render_asset_paths[(size_t)SimObject::Cube] =
+            (std::filesystem::path(DATA_DIR) / "cube_render.obj").string();
+        render_asset_paths[(size_t)SimObject::Wall] =
+            (std::filesystem::path(DATA_DIR) / "wall_render.obj").string();
+        render_asset_paths[(size_t)SimObject::Hider] =
+            (std::filesystem::path(DATA_DIR) / "agent_render.obj").string();
+        render_asset_paths[(size_t)SimObject::Seeker] =
+            (std::filesystem::path(DATA_DIR) / "agent_render.obj").string();
+        render_asset_paths[(size_t)SimObject::Ramp] =
+            (std::filesystem::path(DATA_DIR) / "ramp_render.obj").string();
+        render_asset_paths[(size_t)SimObject::Box] =
+            (std::filesystem::path(DATA_DIR) / "elongated_render.obj").string();
+
+        std::array<const char*, (size_t)SimObject::NumObjects> render_asset_cstrs;
+        for (size_t i = 0; i < render_asset_paths.size(); i++) {
+            render_asset_cstrs[i] = render_asset_paths[i].c_str();
+        }
+
+        std::array<char, 1024> import_err;
+        auto render_assets = imp::ImportedAssets::importFromDisk(
+            render_asset_cstrs, Span<char>(import_err.data(), import_err.size()));
+
+        if (!render_assets.has_value()) {
+            FATAL("Failed to load render assets: %s", import_err);
+        }
+
+        auto materials = std::to_array<imp::SourceMaterial>({
+            { math::Vector4{0.4f, 0.4f, 0.4f, 0.0f}, -1, 0.8f, 0.2f,},
+            { math::Vector4{1.0f, 0.1f, 0.1f, 0.0f}, -1, 0.8f, 0.2f,},
+            { math::Vector4{1.0f, 1.0f, 1.0f, 0.0f}, 1, 0.8f, 1.0f,},
+            { math::Vector4{0.5f, 0.3f, 0.3f, 0.0f},  0, 0.8f, 0.2f,},
+            { render::rgb8ToFloat(191, 108, 10), -1, 0.8f, 0.2f },
+            { render::rgb8ToFloat(12, 144, 150), -1, 0.8f, 0.2f },
+            { render::rgb8ToFloat(230, 230, 230),   -1, 0.8f, 1.0f },
+            { math::Vector4{1.0f, 1.0f, 1.0f, 0.0f}, 2, 0.8f, 1.0f,},
+            });
+
+        // Override materials
+        render_assets->objects[(uint32_t)SimObject::Sphere].meshes[0].materialIDX = 0;
+        render_assets->objects[(uint32_t)SimObject::Plane].meshes[0].materialIDX = 3;
+        render_assets->objects[(uint32_t)SimObject::Cube].meshes[0].materialIDX = 1;
+        render_assets->objects[(uint32_t)SimObject::Wall].meshes[0].materialIDX = 0;
+        render_assets->objects[(uint32_t)SimObject::Hider].meshes[0].materialIDX = 2;
+        render_assets->objects[(uint32_t)SimObject::Hider].meshes[1].materialIDX = 6;
+        render_assets->objects[(uint32_t)SimObject::Hider].meshes[2].materialIDX = 6;
+        render_assets->objects[(uint32_t)SimObject::Seeker].meshes[0].materialIDX = 7;
+        render_assets->objects[(uint32_t)SimObject::Seeker].meshes[1].materialIDX = 6;
+        render_assets->objects[(uint32_t)SimObject::Seeker].meshes[2].materialIDX = 6;
+        render_assets->objects[(uint32_t)SimObject::Ramp].meshes[0].materialIDX = 4;
+        render_assets->objects[(uint32_t)SimObject::Box].meshes[0].materialIDX = 5;
+
+        render_mgr.loadObjects(render_assets->objects, materials, {
+            { (std::filesystem::path(DATA_DIR) /
+               "green_grid.png").string().c_str() },
+            { (std::filesystem::path(DATA_DIR) /
+               "smile.png").string().c_str() },
+            { (std::filesystem::path(DATA_DIR) /
+               "red_smile.png").string().c_str() },
+            });
+
+        render_mgr.configureLighting({
+            { true, math::Vector3{1.0f, 1.0f, -2.0f}, math::Vector3{1.0f, 1.0f, 1.0f} }
+            });
+    }
+
+    Manager::Impl* Manager::Impl::make(const Config& cfg)
+    {
+        GPUHideSeek::Config app_cfg;
+        app_cfg.simFlags = cfg.simFlags;
+        app_cfg.initRandKey = rand::initKey(cfg.randSeed);
+        app_cfg.minHiders = cfg.minHiders;
+        app_cfg.maxHiders = cfg.maxHiders;
+        app_cfg.minSeekers = cfg.minSeekers;
+        app_cfg.maxSeekers = cfg.maxSeekers;
+
+        int32_t max_agents_per_world = cfg.maxHiders + cfg.maxSeekers;
+
+        switch (cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            CUcontext cu_ctx = MWCudaExecutor::initCUDA(cfg.gpuID);
+
+            PhysicsLoader phys_loader(cfg.execMode, 10);
+            loadPhysicsObjects(phys_loader);
+
+            ObjectManager* phys_obj_mgr = &phys_loader.getObjectManager();
+            app_cfg.rigidBodyObjMgr = phys_obj_mgr;
+
+            Optional<RenderGPUState> render_gpu_state =
+                initRenderGPUState(cfg);
+
+            Optional<render::RenderManager> render_mgr =
+                initRenderManager(cfg, render_gpu_state);
+
+            if (render_mgr.has_value()) {
+                loadRenderObjects(*render_mgr);
+                app_cfg.renderBridge = render_mgr->bridge();
+            }
+            else {
+                app_cfg.renderBridge = nullptr;
+            }
+
+            HeapArray<WorldInit> world_inits(cfg.numWorlds);
+
+            MWCudaExecutor mwgpu_exec({
+                .worldInitPtr = world_inits.data(),
+                .numWorldInitBytes = sizeof(WorldInit),
+                .userConfigPtr = &app_cfg,
+                .numUserConfigBytes = sizeof(GPUHideSeek::Config),
+                .numWorldDataBytes = sizeof(Sim),
+                .worldDataAlignment = alignof(Sim),
                 .numWorlds = cfg.numWorlds,
+                .numTaskGraphs = (uint32_t)TaskGraphID::NumTaskGraphs,
                 .numExportedBuffers = (uint32_t)ExportID::NumExports,
-            },
-            app_cfg,
-            world_inits.data(),
-            (uint32_t)TaskGraphID::NumTaskGraphs,
+                }, {
+                    { GPU_HIDESEEK_SRC_LIST },
+                    { GPU_HIDESEEK_COMPILE_FLAGS },
+                    CompileConfig::OptMode::LTO,
+                }, cu_ctx);
+
+            // MWCudaLaunchGraph step_graph = mwgpu_exec.buildLaunchGraph(
+            //     TaskGraphID::Step);
+
+            MWCudaLaunchGraph simulation_graph = mwgpu_exec.buildLaunchGraph(
+                TaskGraphID::Simulate);
+
+            MWCudaLaunchGraph reset_and_update_graph = mwgpu_exec.buildLaunchGraph(
+                TaskGraphID::ResetAndUpdate);
+
+            WorldReset* world_reset_buffer =
+                (WorldReset*)mwgpu_exec.getExported((uint32_t)ExportID::Reset);
+
+            Action* agent_actions_buffer =
+                (Action*)mwgpu_exec.getExported((uint32_t)ExportID::Action);
+
+            HostEventLogging(HostEvent::initEnd);
+            return new CUDAImpl{
+                {
+                    cfg,
+                    max_agents_per_world,
+                    std::move(phys_loader),
+                    std::move(render_gpu_state),
+                    std::move(render_mgr),
+                    world_reset_buffer,
+                    agent_actions_buffer,
+                },
+                std::move(mwgpu_exec),
+                // std::move(step_graph),
+                std::move(simulation_graph),
+                std::move(reset_and_update_graph),
+            };
+#else
+            FATAL("Madrona was not compiled with CUDA support");
+#endif
+        } break;
+        case ExecMode::CPU: {
+            PhysicsLoader phys_loader(cfg.execMode, 10);
+            loadPhysicsObjects(phys_loader);
+
+            ObjectManager* phys_obj_mgr = &phys_loader.getObjectManager();
+            app_cfg.rigidBodyObjMgr = phys_obj_mgr;
+
+            Optional<RenderGPUState> render_gpu_state =
+                initRenderGPUState(cfg);
+
+            Optional<render::RenderManager> render_mgr =
+                initRenderManager(cfg, render_gpu_state);
+
+            if (render_mgr.has_value()) {
+                loadRenderObjects(*render_mgr);
+                app_cfg.renderBridge = render_mgr->bridge();
+            }
+            else {
+                app_cfg.renderBridge = nullptr;
+            }
+
+            HeapArray<WorldInit> world_inits(cfg.numWorlds);
+
+            CPUImpl::TaskGraphT cpu_exec{
+                ThreadPoolExecutor::Config {
+                    .numWorlds = cfg.numWorlds,
+                    .numExportedBuffers = (uint32_t)ExportID::NumExports,
+                },
+                app_cfg,
+                world_inits.data(),
+                (uint32_t)TaskGraphID::NumTaskGraphs,
+            };
+
+            WorldReset* world_reset_buffer =
+                (WorldReset*)cpu_exec.getExported((uint32_t)ExportID::Reset);
+
+            Action* agent_actions_buffer =
+                (Action*)cpu_exec.getExported((uint32_t)ExportID::Action);
+
+            auto cpu_impl = new CPUImpl{
+                {
+                    cfg,
+                    max_agents_per_world,
+                    std::move(phys_loader),
+                    std::move(render_gpu_state),
+                    std::move(render_mgr),
+                    world_reset_buffer,
+                    agent_actions_buffer,
+                },
+                std::move(cpu_exec),
+            };
+
+            HostEventLogging(HostEvent::initEnd);
+
+            return cpu_impl;
+        } break;
+        default: MADRONA_UNREACHABLE();
+        }
+    }
+
+    template <EnumType EnumT>
+    Tensor Manager::Impl::exportStateTensor(EnumT slot,
+        TensorElementType type,
+        Span<const int64_t> dimensions)
+    {
+        void* dev_ptr = nullptr;
+        Optional<int> gpu_id = Optional<int>::none();
+        if (cfg.execMode == ExecMode::CUDA) {
+#ifdef MADRONA_MWGPU_SUPPORT
+            dev_ptr =
+                static_cast<CUDAImpl*>(this)->mwGPU.getExported((uint32_t)slot);
+            gpu_id = cfg.gpuID;
+#endif
+        }
+        else {
+            dev_ptr = static_cast<CPUImpl*>(this)->cpuExec.getExported((uint32_t)slot);
+        }
+
+        return Tensor(dev_ptr, type, dimensions, gpu_id);
+    }
+
+    Manager::Manager(const Config& cfg)
+        : impl_(Impl::make(cfg))
+    {}
+
+    Manager::~Manager() {
+        switch (impl_->cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            delete static_cast<CUDAImpl*>(impl_);
+#endif
+        } break;
+        case ExecMode::CPU: {
+            delete static_cast<CPUImpl*>(impl_);
+        } break;
+        }
+    }
+
+    void Manager::init()
+    {
+        switch (impl_->cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            static_cast<CUDAImpl*>(impl_)->init();
+#endif
+        } break;
+        case ExecMode::CPU: {
+            static_cast<CPUImpl*>(impl_)->init();
+        } break;
+        }
+
+        if (impl_->renderMgr.has_value()) {
+            impl_->renderMgr->readECS();
+        }
+
+        if (impl_->cfg.enableBatchRenderer) {
+            impl_->renderMgr->batchRender();
+        }
+    }
+
+    void Manager::step()
+    {
+        switch (impl_->cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            static_cast<CUDAImpl*>(impl_)->step();
+#endif
+        } break;
+        case ExecMode::CPU: {
+            static_cast<CPUImpl*>(impl_)->step();
+        } break;
+        }
+
+        if (impl_->renderMgr.has_value()) {
+            impl_->renderMgr->readECS();
+        }
+
+        if (impl_->cfg.enableBatchRenderer) {
+            impl_->renderMgr->batchRender();
+        }
+    }
+
+    void Manager::simulate()
+    {
+        switch (impl_->cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            static_cast<CUDAImpl*>(impl_)->simulate();
+#endif
+        } break;
+        case ExecMode::CPU: {
+            static_cast<CPUImpl*>(impl_)->simulate();
+        } break;
+        }
+
+        if (impl_->renderMgr.has_value()) {
+            impl_->renderMgr->readECS();
+        }
+
+        if (impl_->cfg.enableBatchRenderer) {
+            impl_->renderMgr->batchRender();
+        }
+    }
+
+    void Manager::resetandupdate()
+    {
+        switch (impl_->cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            static_cast<CUDAImpl*>(impl_)->resetandupdate();
+#endif
+        } break;
+        case ExecMode::CPU: {
+            static_cast<CPUImpl*>(impl_)->resetandupdate();
+        } break;
+        }
+
+        if (impl_->renderMgr.has_value()) {
+            impl_->renderMgr->readECS();
+        }
+
+        if (impl_->cfg.enableBatchRenderer) {
+            impl_->renderMgr->batchRender();
+        }
+    }
+
+#ifdef MADRONA_MWGPU_SUPPORT
+    void Manager::gpuStreamInit(cudaStream_t strm, void** buffers)
+    {
+        switch (impl_->cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            static_cast<CUDAImpl*>(impl_)->gpuStreamInit(strm, buffers, *this);
+#endif
+        } break;
+        case ExecMode::CPU: {
+            static_cast<CPUImpl*>(impl_)->gpuStreamInit(strm, buffers, *this);
+        } break;
+        }
+
+        if (impl_->renderMgr.has_value()) {
+            assert(false);
+        }
+    }
+
+    void Manager::gpuStreamStep(cudaStream_t strm, void** buffers)
+    {
+        switch (impl_->cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            static_cast<CUDAImpl*>(impl_)->gpuStreamStep(strm, buffers, *this);
+#endif
+        } break;
+        case ExecMode::CPU: {
+            static_cast<CPUImpl*>(impl_)->gpuStreamStep(strm, buffers, *this);
+        } break;
+        }
+
+        if (impl_->renderMgr.has_value()) {
+            assert(false);
+        }
+    }
+
+    void Manager::gpuStreamSimulate(cudaStream_t strm, void** buffers)
+    {
+        switch (impl_->cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            static_cast<CUDAImpl*>(impl_)->gpuStreamSimulate(strm, buffers, *this);
+#endif
+        } break;
+        case ExecMode::CPU: {
+            static_cast<CPUImpl*>(impl_)->gpuStreamSimulate(strm, buffers, *this);
+        } break;
+        }
+
+        if (impl_->renderMgr.has_value()) {
+            assert(false);
+        }
+    }
+
+    void Manager::gpuStreamResetAndUpdate(cudaStream_t strm, void** buffers)
+    {
+        switch (impl_->cfg.execMode) {
+        case ExecMode::CUDA: {
+#ifdef MADRONA_MWGPU_SUPPORT
+            static_cast<CUDAImpl*>(impl_)->gpuStreamResetAndUpdate(strm, buffers, *this);
+#endif
+        } break;
+        case ExecMode::CPU: {
+            static_cast<CPUImpl*>(impl_)->gpuStreamResetAndUpdate(strm, buffers, *this);
+        } break;
+        }
+
+        if (impl_->renderMgr.has_value()) {
+            assert(false);
+        }
+    }
+
+#endif
+
+    Tensor Manager::resetTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::Reset, TensorElementType::Int32,
+            { impl_->cfg.numWorlds, 1 });
+    }
+
+    Tensor Manager::doneTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::Done, TensorElementType::Int32,
+            { impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1 });
+    }
+
+    madrona::py::Tensor Manager::prepCounterTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::PrepCounter, TensorElementType::Int32,
+            { impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1 });
+    }
+
+    Tensor Manager::actionTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::Action, TensorElementType::Int32,
+            { impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 5 });
+    }
+
+    Tensor Manager::rewardTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::Reward, TensorElementType::Float32,
+            { impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1 });
+    }
+
+
+    Tensor Manager::selfDataTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::SelfObs, TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                sizeof(SelfObservation) / sizeof(float),
+            });
+    }
+
+    Tensor Manager::selfTypeTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::SelfType, TensorElementType::Int32,
+            { impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1 });
+    }
+
+    Tensor Manager::selfMaskTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::SelfMask, TensorElementType::Float32,
+            { impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1 });
+    }
+
+
+    madrona::py::Tensor Manager::agentDataTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::AgentObsData, TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                consts::maxAgents - 1,
+                sizeof(AgentObservation) / sizeof(float),
+            });
+    }
+
+    madrona::py::Tensor Manager::boxDataTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::BoxObsData, TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                consts::maxBoxes,
+                sizeof(BoxObservation) / sizeof(float),
+            });
+    }
+
+    madrona::py::Tensor Manager::rampDataTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::RampObsData, TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                consts::maxRamps,
+                sizeof(RampObservation) / sizeof(float),
+            });
+    }
+
+    madrona::py::Tensor Manager::visibleAgentsMaskTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::AgentVisMasks, TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                consts::maxAgents - 1,
+                1,
+            });
+    }
+
+    madrona::py::Tensor Manager::visibleBoxesMaskTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::BoxVisMasks, TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                consts::maxBoxes,
+                1,
+            });
+    }
+
+    madrona::py::Tensor Manager::visibleRampsMaskTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::RampVisMasks, TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                consts::maxRamps,
+                1,
+            });
+    }
+
+    madrona::py::Tensor Manager::lidarTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::Lidar, TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                30,
+            });
+    }
+
+    madrona::py::Tensor Manager::seedTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::Seed, TensorElementType::Int32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                sizeof(Seed) / sizeof(int32_t),
+            });
+    }
+
+    madrona::py::Tensor Manager::globalPositionsTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::GlobalDebugPositions, TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds,
+                consts::maxBoxes + consts::maxRamps +
+                    consts::maxAgents,
+                2,
+            });
+    }
+
+    Tensor Manager::depthTensor() const
+    {
+        const float* depth_ptr = impl_->renderMgr->batchRendererDepthOut();
+
+        return Tensor((void*)depth_ptr, TensorElementType::Float32, {
+            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+            impl_->cfg.batchRenderViewHeight,
+            impl_->cfg.batchRenderViewWidth,
+            1,
+            }, impl_->cfg.gpuID);
+    }
+
+    Tensor Manager::rgbTensor() const
+    {
+        const uint8_t* rgb_ptr = impl_->renderMgr->batchRendererRGBOut();
+
+        return Tensor((void*)rgb_ptr, TensorElementType::UInt8, {
+            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+            impl_->cfg.batchRenderViewHeight,
+            impl_->cfg.batchRenderViewWidth,
+            4,
+            }, impl_->cfg.gpuID);
+    }
+
+    void Manager::triggerReset(CountT world_idx, CountT level_idx)
+    {
+        WorldReset reset{
+            (int32_t)level_idx,
         };
 
-        WorldReset *world_reset_buffer =
-            (WorldReset *)cpu_exec.getExported((uint32_t)ExportID::Reset);
+        auto* reset_ptr = impl_->resetsPointer + world_idx;
 
-        Action *agent_actions_buffer = 
-            (Action *)cpu_exec.getExported((uint32_t)ExportID::Action);
+        if (impl_->cfg.execMode == ExecMode::CUDA) {
+#ifdef MADRONA_MWGPU_SUPPORT
+            cudaMemcpy(reset_ptr, &reset, sizeof(WorldReset),
+                cudaMemcpyHostToDevice);
+#endif
+        }
+        else {
+            *reset_ptr = reset;
+        }
+    }
 
-        auto cpu_impl = new CPUImpl {
-            { 
-                cfg,
-                max_agents_per_world,
-                std::move(phys_loader),
-                std::move(render_gpu_state),
-                std::move(render_mgr),
-                world_reset_buffer,
-                agent_actions_buffer,
-            },
-            std::move(cpu_exec),
+    void Manager::setAction(CountT agent_idx,
+        int32_t x, int32_t y, int32_t r,
+        bool g, bool l)
+    {
+        Action action{
+            .x = x,
+            .y = y,
+            .r = r,
+            .g = (int32_t)g,
+            .l = (int32_t)l,
         };
 
-        HostEventLogging(HostEvent::initEnd);
+        auto* action_ptr = impl_->actionsPointer + agent_idx;
 
-        return cpu_impl;
-    } break;
-    default: MADRONA_UNREACHABLE();
-    }
-}
-
-template <EnumType EnumT>
-Tensor Manager::Impl::exportStateTensor(EnumT slot,
-                                        TensorElementType type,
-                                        Span<const int64_t> dimensions)
-{
-    void *dev_ptr = nullptr;
-    Optional<int> gpu_id = Optional<int>::none();
-    if (cfg.execMode == ExecMode::CUDA) {
+        if (impl_->cfg.execMode == ExecMode::CUDA) {
 #ifdef MADRONA_MWGPU_SUPPORT
-        dev_ptr =
-            static_cast<CUDAImpl *>(this)->mwGPU.getExported((uint32_t)slot);
-        gpu_id = cfg.gpuID;
+            cudaMemcpy(action_ptr, &action, sizeof(Action),
+                cudaMemcpyHostToDevice);
 #endif
-    } else {
-        dev_ptr = static_cast<CPUImpl *>(this)->cpuExec.getExported((uint32_t)slot);
+        }
+        else {
+            *action_ptr = action;
+        }
     }
 
-    return Tensor(dev_ptr, type, dimensions, gpu_id);
-}
-
-Manager::Manager(const Config &cfg)
-    : impl_(Impl::make(cfg))
-{}
-
-Manager::~Manager() {
-    switch (impl_->cfg.execMode) {
-    case ExecMode::CUDA: {
-#ifdef MADRONA_MWGPU_SUPPORT
-        delete static_cast<CUDAImpl *>(impl_);
-#endif
-    } break;
-    case ExecMode::CPU : {
-        delete static_cast<CPUImpl *>(impl_);
-    } break;
-    }
-}
-
-void Manager::init()
-{
-    switch (impl_->cfg.execMode) {
-    case ExecMode::CUDA: {
-#ifdef MADRONA_MWGPU_SUPPORT
-        static_cast<CUDAImpl *>(impl_)->init();
-#endif
-    } break;
-    case ExecMode::CPU: {
-        static_cast<CPUImpl *>(impl_)->init();
-    } break;
+    render::RenderManager& Manager::getRenderManager()
+    {
+        return *impl_->renderMgr;
     }
 
-    if (impl_->renderMgr.has_value()) {
-        impl_->renderMgr->readECS();
+    Tensor Manager::episodeResultTensor() const
+    {
+        return impl_->exportStateTensor(ExportID::EpisodeResult,
+            TensorElementType::Float32,
+            {
+                impl_->cfg.numWorlds,
+                sizeof(EpisodeResult) / sizeof(float),
+            });
     }
 
-    if (impl_->cfg.enableBatchRenderer) {
-        impl_->renderMgr->batchRender();
-    }
-}
-
-void Manager::step()
-{
-    switch (impl_->cfg.execMode) {
-    case ExecMode::CUDA: {
-#ifdef MADRONA_MWGPU_SUPPORT
-        static_cast<CUDAImpl *>(impl_)->step();
-#endif
-    } break;
-    case ExecMode::CPU: {
-        static_cast<CPUImpl *>(impl_)->step();
-    } break;
+    Tensor Manager::policyAssignmentsTensor() const
+    {
+        return impl_->exportStateTensor(
+            ExportID::AgentPolicy,
+            TensorElementType::Int32,
+            {
+                impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
+                sizeof(AgentPolicy) / sizeof(int32_t)
+            });
     }
 
-    if (impl_->renderMgr.has_value()) {
-        impl_->renderMgr->readECS();
-    }
+    TrainInterface Manager::trainInterface() const
+    {
+        auto pbt_inputs = std::to_array<NamedTensorInterface>({
+            { "policy_assignments", policyAssignmentsTensor().interface() },
+            });
 
-    if (impl_->cfg.enableBatchRenderer) {
-        impl_->renderMgr->batchRender();
-    }
-}
+        auto pbt_outputs = std::to_array<NamedTensorInterface>({
+            { "episode_results", episodeResultTensor().interface() },
+            });
 
-#ifdef MADRONA_MWGPU_SUPPORT
-void Manager::gpuStreamInit(cudaStream_t strm, void **buffers)
-{
-    switch (impl_->cfg.execMode) {
-    case ExecMode::CUDA: {
-#ifdef MADRONA_MWGPU_SUPPORT
-        static_cast<CUDAImpl *>(impl_)->gpuStreamInit(strm, buffers, *this);
-#endif
-    } break;
-    case ExecMode::CPU: {
-        static_cast<CPUImpl *>(impl_)->gpuStreamInit(strm, buffers, *this);
-    } break;
-    }
-
-    if (impl_->renderMgr.has_value()) {
-        assert(false);
-    }
-}
-
-void Manager::gpuStreamStep(cudaStream_t strm, void **buffers)
-{
-    switch (impl_->cfg.execMode) {
-    case ExecMode::CUDA: {
-#ifdef MADRONA_MWGPU_SUPPORT
-        static_cast<CUDAImpl *>(impl_)->gpuStreamStep(strm, buffers, *this);
-#endif
-    } break;
-    case ExecMode::CPU: {
-        static_cast<CPUImpl *>(impl_)->gpuStreamStep(strm, buffers, *this);
-    } break;
-    }
-    
-    if (impl_->renderMgr.has_value()) {
-        assert(false);
-    }
-}
-
-#endif
-
-Tensor Manager::resetTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::Reset, TensorElementType::Int32,
-        {impl_->cfg.numWorlds, 1});
-}
-
-Tensor Manager::doneTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::Done, TensorElementType::Int32,
-        {impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1});
-}
-
-madrona::py::Tensor Manager::prepCounterTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::PrepCounter, TensorElementType::Int32,
-        {impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1});
-}
-
-Tensor Manager::actionTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::Action, TensorElementType::Int32,
-        {impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 5});
-}
-
-Tensor Manager::rewardTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::Reward, TensorElementType::Float32,
-        {impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1});
-}
-
-
-Tensor Manager::selfDataTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::SelfObs, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            sizeof(SelfObservation) / sizeof(float),
-        });
-}
-
-Tensor Manager::selfTypeTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::SelfType, TensorElementType::Int32,
-        {impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1});
-}
-
-Tensor Manager::selfMaskTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::SelfMask, TensorElementType::Float32,
-        {impl_->cfg.numWorlds * impl_->maxAgentsPerWorld, 1});
-}
-
-
-madrona::py::Tensor Manager::agentDataTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::AgentObsData, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            consts::maxAgents - 1,
-            sizeof(AgentObservation) / sizeof(float),
-        });
-}
-
-madrona::py::Tensor Manager::boxDataTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::BoxObsData, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            consts::maxBoxes,
-            sizeof(BoxObservation) / sizeof(float),
-        });
-}
-
-madrona::py::Tensor Manager::rampDataTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::RampObsData, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            consts::maxRamps,
-            sizeof(RampObservation) / sizeof(float),
-        });
-}
-
-madrona::py::Tensor Manager::visibleAgentsMaskTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::AgentVisMasks, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            consts::maxAgents - 1,
-            1,
-        });
-}
-
-madrona::py::Tensor Manager::visibleBoxesMaskTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::BoxVisMasks, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            consts::maxBoxes,
-            1,
-        });
-}
-
-madrona::py::Tensor Manager::visibleRampsMaskTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::RampVisMasks, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            consts::maxRamps,
-            1,
-        });
-}
-
-madrona::py::Tensor Manager::lidarTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::Lidar, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            30,
-        });
-}
-
-madrona::py::Tensor Manager::seedTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::Seed, TensorElementType::Int32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            sizeof(Seed) / sizeof(int32_t),
-        });
-}
-
-madrona::py::Tensor Manager::globalPositionsTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::GlobalDebugPositions, TensorElementType::Float32,
-        {
-            impl_->cfg.numWorlds,
-            consts::maxBoxes + consts::maxRamps +
-                consts::maxAgents,
-            2,
-        });
-}
-
-Tensor Manager::depthTensor() const
-{
-    const float *depth_ptr = impl_->renderMgr->batchRendererDepthOut();
-
-    return Tensor((void *)depth_ptr, TensorElementType::Float32, {
-        impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-        impl_->cfg.batchRenderViewHeight,
-        impl_->cfg.batchRenderViewWidth,
-        1,
-    }, impl_->cfg.gpuID);
-}
-
-Tensor Manager::rgbTensor() const
-{
-    const uint8_t *rgb_ptr = impl_->renderMgr->batchRendererRGBOut();
-
-    return Tensor((void *)rgb_ptr, TensorElementType::UInt8, {
-        impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-        impl_->cfg.batchRenderViewHeight,
-        impl_->cfg.batchRenderViewWidth,
-        4,
-    }, impl_->cfg.gpuID);
-}
-
-void Manager::triggerReset(CountT world_idx, CountT level_idx)
-{
-    WorldReset reset {
-        (int32_t)level_idx,
-    };
-
-    auto *reset_ptr = impl_->resetsPointer + world_idx;
-
-    if (impl_->cfg.execMode == ExecMode::CUDA) {
-#ifdef MADRONA_MWGPU_SUPPORT
-        cudaMemcpy(reset_ptr, &reset, sizeof(WorldReset),
-                   cudaMemcpyHostToDevice);
-#endif
-    }  else {
-        *reset_ptr = reset;
-    }
-}
-
-void Manager::setAction(CountT agent_idx,
-                        int32_t x, int32_t y, int32_t r,
-                        bool g, bool l)
-{
-    Action action { 
-        .x = x,
-        .y = y,
-        .r = r,
-        .g = (int32_t)g,
-        .l = (int32_t)l,
-    };
-
-    auto *action_ptr = impl_->actionsPointer + agent_idx;
-
-    if (impl_->cfg.execMode == ExecMode::CUDA) {
-#ifdef MADRONA_MWGPU_SUPPORT
-        cudaMemcpy(action_ptr, &action, sizeof(Action),
-                   cudaMemcpyHostToDevice);
-#endif
-    } else {
-        *action_ptr = action;
-    }
-}
-
-render::RenderManager & Manager::getRenderManager()
-{
-    return *impl_->renderMgr;
-}
-
-Tensor Manager::episodeResultTensor() const
-{
-    return impl_->exportStateTensor(ExportID::EpisodeResult,
-                                    TensorElementType::Float32,
-                                    {
-                                        impl_->cfg.numWorlds,
-                                        sizeof(EpisodeResult) / sizeof(float),
-                                    });
-}
-
-Tensor Manager::policyAssignmentsTensor() const
-{
-    return impl_->exportStateTensor(
-        ExportID::AgentPolicy,
-        TensorElementType::Int32,
-        {
-            impl_->cfg.numWorlds * impl_->maxAgentsPerWorld,
-            sizeof(AgentPolicy) / sizeof(int32_t)
-        });
-}
-
-TrainInterface Manager::trainInterface() const
-{
-    auto pbt_inputs = std::to_array<NamedTensorInterface>({
-        { "policy_assignments", policyAssignmentsTensor().interface() },
-    });
-
-    auto pbt_outputs = std::to_array<NamedTensorInterface>({
-        { "episode_results", episodeResultTensor().interface() },
-    });
-
-    return TrainInterface {
-        {
-            .actions = actionTensor().interface(),
-            .resets = resetTensor().interface(),
-            .pbt = impl_->cfg.numPBTPolicies > 0 ?
-                pbt_inputs : Span<const NamedTensorInterface>(nullptr, 0),
-        },
-        {
-            .observations = {
-                { "prep_counter", prepCounterTensor().interface() },
-                { "self_data", selfDataTensor().interface() },
-                { "self_type", selfTypeTensor().interface() },
-                { "self_mask", selfMaskTensor().interface() },
-                { "self_lidar", lidarTensor().interface() },
-                { "agent_data", agentDataTensor().interface() },
-                { "box_data", boxDataTensor().interface() },
-                { "ramp_data", rampDataTensor().interface() },
-                { "vis_agents_mask", visibleAgentsMaskTensor().interface() },
-                { "vis_boxes_mask", visibleBoxesMaskTensor().interface() },
-                { "vis_ramps_mask", visibleRampsMaskTensor().interface() },
+        return TrainInterface{
+            {
+                .actions = actionTensor().interface(),
+                .resets = resetTensor().interface(),
+                .pbt = impl_->cfg.numPBTPolicies > 0 ?
+                    pbt_inputs : Span<const NamedTensorInterface>(nullptr, 0),
             },
-            .rewards = rewardTensor().interface(),
-            .dones = doneTensor().interface(),
-            .pbt = impl_->cfg.numPBTPolicies > 0 ?
-                pbt_outputs : Span<const NamedTensorInterface>(nullptr, 0),
-        },
-    };
-}
+            {
+                .observations = {
+                    { "prep_counter", prepCounterTensor().interface() },
+                    { "self_data", selfDataTensor().interface() },
+                    { "self_type", selfTypeTensor().interface() },
+                    { "self_mask", selfMaskTensor().interface() },
+                    { "self_lidar", lidarTensor().interface() },
+                    { "agent_data", agentDataTensor().interface() },
+                    { "box_data", boxDataTensor().interface() },
+                    { "ramp_data", rampDataTensor().interface() },
+                    { "vis_agents_mask", visibleAgentsMaskTensor().interface() },
+                    { "vis_boxes_mask", visibleBoxesMaskTensor().interface() },
+                    { "vis_ramps_mask", visibleRampsMaskTensor().interface() },
+                },
+                .rewards = rewardTensor().interface(),
+                .dones = doneTensor().interface(),
+                .pbt = impl_->cfg.numPBTPolicies > 0 ?
+                    pbt_outputs : Span<const NamedTensorInterface>(nullptr, 0),
+            },
+        };
+    }
 
 }

--- a/src/mgr.hpp
+++ b/src/mgr.hpp
@@ -11,76 +11,80 @@
 
 namespace GPUHideSeek {
 
-class Manager {
-public:
-    struct Config {
-        madrona::ExecMode execMode;
-        int gpuID;
-        uint32_t numWorlds;
-        SimFlags simFlags;
-        uint32_t randSeed;
-        uint32_t minHiders;
-        uint32_t maxHiders;
-        uint32_t minSeekers;
-        uint32_t maxSeekers;
-        uint32_t numPBTPolicies;
-        bool enableBatchRenderer;
-        uint32_t batchRenderViewWidth = 64;
-        uint32_t batchRenderViewHeight = 64;
-        madrona::render::APIBackend *extRenderAPI = nullptr;
-        madrona::render::GPUDevice *extRenderDev = nullptr;
-    };
+    class Manager {
+    public:
+        struct Config {
+            madrona::ExecMode execMode;
+            int gpuID;
+            uint32_t numWorlds;
+            SimFlags simFlags;
+            uint32_t randSeed;
+            uint32_t minHiders;
+            uint32_t maxHiders;
+            uint32_t minSeekers;
+            uint32_t maxSeekers;
+            uint32_t numPBTPolicies;
+            bool enableBatchRenderer;
+            uint32_t batchRenderViewWidth = 64;
+            uint32_t batchRenderViewHeight = 64;
+            madrona::render::APIBackend* extRenderAPI = nullptr;
+            madrona::render::GPUDevice* extRenderDev = nullptr;
+        };
 
-    Manager(const Config &cfg);
-    ~Manager();
+        Manager(const Config& cfg);
+        ~Manager();
 
-    void init();
-    void step();
+        void init();
+        void step();
+        void simulate();
+        void resetandupdate();
 
 #ifdef MADRONA_MWGPU_SUPPORT
-    void gpuStreamInit(cudaStream_t strm, void **buffers);
-    void gpuStreamStep(cudaStream_t strm, void **buffers);
+        void gpuStreamInit(cudaStream_t strm, void** buffers);
+        void gpuStreamStep(cudaStream_t strm, void** buffers);
+        void gpuStreamSimulate(cudaStream_t strm, void** buffers);
+        void gpuStreamResetAndUpdate(cudaStream_t strm, void** buffers);
 #endif
 
-    madrona::py::Tensor resetTensor() const;
-    madrona::py::Tensor doneTensor() const;
-    madrona::py::Tensor prepCounterTensor() const;
-    madrona::py::Tensor actionTensor() const;
-    madrona::py::Tensor rewardTensor() const;
-    madrona::py::Tensor selfDataTensor() const;
-    madrona::py::Tensor selfTypeTensor() const;
-    madrona::py::Tensor selfMaskTensor() const;
-    madrona::py::Tensor agentDataTensor() const;
-    madrona::py::Tensor boxDataTensor() const;
-    madrona::py::Tensor rampDataTensor() const;
-    madrona::py::Tensor visibleAgentsMaskTensor() const;
-    madrona::py::Tensor visibleBoxesMaskTensor() const;
-    madrona::py::Tensor visibleRampsMaskTensor() const;
-    madrona::py::Tensor globalPositionsTensor() const;
-    madrona::py::Tensor lidarTensor() const;
-    madrona::py::Tensor seedTensor() const;
+        madrona::py::Tensor resetTensor() const;
+        madrona::py::Tensor doneTensor() const;
+        madrona::py::Tensor prepCounterTensor() const;
+        madrona::py::Tensor actionTensor() const;
+        madrona::py::Tensor rewardTensor() const;
+        madrona::py::Tensor selfDataTensor() const;
+        madrona::py::Tensor selfTypeTensor() const;
+        madrona::py::Tensor selfMaskTensor() const;
+        madrona::py::Tensor agentDataTensor() const;
+        madrona::py::Tensor boxDataTensor() const;
+        madrona::py::Tensor rampDataTensor() const;
+        madrona::py::Tensor visibleAgentsMaskTensor() const;
+        madrona::py::Tensor visibleBoxesMaskTensor() const;
+        madrona::py::Tensor visibleRampsMaskTensor() const;
+        madrona::py::Tensor globalPositionsTensor() const;
+        madrona::py::Tensor lidarTensor() const;
+        madrona::py::Tensor seedTensor() const;
 
-    madrona::py::Tensor depthTensor() const;
-    madrona::py::Tensor rgbTensor() const;
+        madrona::py::Tensor depthTensor() const;
+        madrona::py::Tensor rgbTensor() const;
 
-    void triggerReset(madrona::CountT world_idx,
-                      madrona::CountT level_idx);
-    void setAction(madrona::CountT agent_idx,
-                   int32_t x, int32_t y, int32_t r,
-                   bool g, bool l);
+        void triggerReset(madrona::CountT world_idx,
+            madrona::CountT level_idx);
+        void setAction(madrona::CountT agent_idx,
+            int32_t x, int32_t y, int32_t r,
+            bool g, bool l);
 
-    madrona::render::RenderManager & getRenderManager();
+        madrona::render::RenderManager& getRenderManager();
 
-    madrona::py::Tensor policyAssignmentsTensor() const;
-    madrona::py::Tensor episodeResultTensor() const;
-    madrona::py::TrainInterface trainInterface() const;
+        madrona::py::Tensor policyAssignmentsTensor() const;
+        madrona::py::Tensor episodeResultTensor() const;
+        madrona::py::TrainInterface trainInterface() const;
 
-private:
-    struct Impl;
-    struct CPUImpl;
-    struct CUDAImpl;
+    private:
+        struct Impl;
+        struct CPUImpl;
+        struct CUDAImpl;
 
-    Impl *impl_;
-};
+        Impl* impl_;
+    };
 
 }

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -66,7 +66,7 @@ enum class ExportID : uint32_t {
 
 enum class TaskGraphID : uint32_t {
     Init,
-    Step,
+    //Step,
     Simulate,
     ResetAndUpdate,
     NumTaskGraphs,

--- a/src/sim.hpp
+++ b/src/sim.hpp
@@ -67,6 +67,8 @@ enum class ExportID : uint32_t {
 enum class TaskGraphID : uint32_t {
     Init,
     Step,
+    Simulate,
+    ResetAndUpdate,
     NumTaskGraphs,
 };
 

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
 #endif
 
     WindowManager wm {};
-    WindowHandle window = wm.makeWindow("Hide & Seek", 2730, 1536);
+    WindowHandle window = wm.makeWindow("Hide & Seek", 1024, 1024);
     render::GPUHandle render_gpu = wm.initGPU(0, { window.get() });
 
     Manager mgr({


### PR DESCRIPTION
bring changes from split task graph branch into new branch starting at the new update

This is a repackaging of #1 but starting at the new update head.  This was easier than trying to rebase when the original branch was started at a HEAD that had different submodules. 